### PR TITLE
Added missing build dep to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,11 @@ Build dependencies on Debian/Ubuntu:
 * kdoctools-dev
 * libxi-dev
 * libwacom-dev
+* libxcb-xinput-dev
 
 You can install them by running:
 
-    $ apt install g++ cmake extra-cmake-modules gettext libqt5x11extras5-dev qtdeclarative5-dev libkf5coreaddons-dev libkf5i18n-dev libkf5dbusaddons-dev libkf5globalaccel-dev libkf5config-dev libkf5xmlgui-dev libkf5notifications-dev plasma-framework-dev kdoctools-dev libxi-dev libwacom-dev
+    $ apt install g++ cmake extra-cmake-modules gettext libqt5x11extras5-dev qtdeclarative5-dev libkf5coreaddons-dev libkf5i18n-dev libkf5dbusaddons-dev libkf5globalaccel-dev libkf5config-dev libkf5xmlgui-dev libkf5notifications-dev plasma-framework-dev kdoctools-dev libxi-dev libwacom-dev libxcb-xinput-dev
 
 Building from source
 --------------------


### PR DESCRIPTION
There was no `libxcb-xinput-dev` package on my Kubuntu, so I've added it after investigating solution.

Error was:
```
-- Could NOT find XCB_XINPUT (missing: XCB_XINPUT_LIBRARY XCB_XINPUT_INCLUDE_DIR) (found version "")
CMake Error at /usr/share/cmake-3.12/Modules/FindPackageHandleStandardArgs.cmake:137 (message):
Could NOT find XCB (missing: XINPUT) (found version "1.13.1")
Call Stack (most recent call first):
/usr/share/cmake-3.12/Modules/FindPackageHandleStandardArgs.cmake:378 (_FPHSA_FAILURE_MESSAGE)
/usr/share/ECM/find-modules/FindXCB.cmake:187 (find_package_handle_standard_args)
CMakeLists.txt:26 (find_package)
```